### PR TITLE
Added a way to use different region

### DIFF
--- a/vault/aws/env.py
+++ b/vault/aws/env.py
@@ -4,15 +4,16 @@ from vault.executor import ExecutorEnv
 
 class AwsEnv(ExecutorEnv):
 
-    def __init__(self, profile_details, credentials: AuthResponse):
+    def __init__(self, profile_details, credentials: AuthResponse, region=None):
         self.profile_details = profile_details
+        self.region = self.profile_details['region'] if region is None else region
         self.credentials = credentials
 
     def setup(self) -> dict:
         environments = {}
-        if 'region' in self.profile_details:
-            environments["AWS_DEFAULT_REGION"] = self.profile_details['region']
-            environments["AWS_REGION"] = self.profile_details['region']
+        if self.region is not None:
+            environments["AWS_DEFAULT_REGION"] = self.region
+            environments["AWS_REGION"] = self.region
         return {
                    "AWS_ACCESS_KEY_ID": self.credentials.aws_access_key_id,
                    "AWS_SECRET_ACCESS_KEY": self.credentials.aws_secret_access_key,

--- a/vault/cli.py
+++ b/vault/cli.py
@@ -1,4 +1,3 @@
-import os
 from functools import update_wrapper
 
 import click
@@ -23,13 +22,14 @@ def pass_exec_config(fn):
     def _decorator():
         @click.pass_context
         @click.option("--profile", help="AWS profile", default="local")
+        @click.option("--region", help="AWS region to use")
         @click.option("--config", help="AWS config file", default="~/.aws/config")
         @click.option("--mfa-stdin", help="Read MFA code from stdin", default=False, is_flag=True)
-        def _fn(ctx, profile, config, mfa_stdin, *args, **kwargs):
+        def _fn(ctx, profile, config, mfa_stdin, region, *args, **kwargs):
             with AwsConfigReader(config_path=config) as config_parser:
-                credentials = auth.Auth(config_parser[profile], mfa_stdin=mfa_stdin).auth()
-                env = AwsEnv(config_parser[profile], credentials)
-                obj = ExecConfig(profile, credentials, env, mfa_stdin)
+                credentials = auth.Auth(config_parser[profile], mfa_stdin=mfa_stdin, region=region).auth()
+                env = AwsEnv(config_parser[profile], credentials, region=region)
+                obj = ExecConfig(profile, credentials, env, mfa_stdin, region)
             return ctx.invoke(fn, obj, *args, **kwargs)
 
         return update_wrapper(_fn, fn)

--- a/vault/executor.py
+++ b/vault/executor.py
@@ -12,11 +12,12 @@ class ExecConfig(object):
     __credentials = None
     __env = None
 
-    def __init__(self, profile, c: Credentials, e, mfa_stdin):
+    def __init__(self, profile, c: Credentials, e, mfa_stdin, region):
         self.__profile = profile
         self.__credentials = c
         self.__env = e
         self.__mfa_stdin = mfa_stdin
+        self.__region = region
 
     @property
     def profile(self):
@@ -33,6 +34,10 @@ class ExecConfig(object):
     @property
     def mfa_stdin(self):
         return self.__mfa_stdin
+
+    @property
+    def region(self):
+        return self.__region
 
 
 class ExecutorEnv(ABC):


### PR DESCRIPTION
Added a way to use different region. Add `--region=<region>`, something like that:
```
# pyvault exec --profile=stage-power-user --region=us-east-1 -- aws dynamodb describe-table --table-name=table

```