### PR TITLE
fix: pass region through MfaAssumeRoleProvider

### DIFF
--- a/vault/aws/auth.py
+++ b/vault/aws/auth.py
@@ -74,8 +74,8 @@ class AssumeRoleProvider(authProvider):
 
 
 class MfaAssumeRoleProvider(AssumeRoleProvider):
-    def __init__(self, profile, mfa_stdin=False):
-        AssumeRoleProvider.__init__(self, profile)
+    def __init__(self, profile, mfa_stdin=False, region=None):
+        AssumeRoleProvider.__init__(self, profile, region=region)
         self.value = None
         self.mfa_stdin = mfa_stdin
 
@@ -187,7 +187,7 @@ class Auth(auth.Auth):
         def get_auth():
             if 'role_arn' in self.profile:
                 if 'mfa_serial' in self.profile:
-                    return MfaAssumeRoleProvider(self.profile, mfa_stdin=self.mfa_stdin).auth()
+                    return MfaAssumeRoleProvider(self.profile, mfa_stdin=self.mfa_stdin, region=self.region).auth()
                 return AssumeRoleProvider(self.profile, region=self.region).auth()
             return SSORoleProvider(self.profile, region=self.region).auth()
 


### PR DESCRIPTION
## Summary

- `MfaAssumeRoleProvider.__init__` did not accept a `region` parameter and never forwarded it to `AssumeRoleProvider`, so `--region` was silently ignored for MFA-based role assumption
- Added `region=None` to `MfaAssumeRoleProvider.__init__` and forwarded it to the parent
- Updated the call site in `Auth.do_auth` to pass `self.region`

## Test plan

- [ ] Run `pyvault exec --profile=<mfa-profile> --region=us-west-2 -- aws sts get-caller-identity` and confirm STS call uses `us-west-2`
- [ ] Run without `--region` flag and confirm falls back to profile's configured region

🤖 Generated with [Claude Code](https://claude.com/claude-code)