### PR TITLE
fix: remove incorrect ExternalId from MFA assume_role

### DIFF
--- a/vault/aws/auth.py
+++ b/vault/aws/auth.py
@@ -94,8 +94,7 @@ class MfaAssumeRoleProvider(AssumeRoleProvider):
             RoleSessionName='AssumeRoleSession',
             RoleArn=self.profile['role_arn'],
             SerialNumber=self.profile['mfa_serial'],
-            TokenCode=value,
-            ExternalId=self.profile['mfa_serial']
+            TokenCode=value
         )
 
 


### PR DESCRIPTION
## Summary

- `ExternalId` in `assume_role` is a cross-account trust policy concept — it is used when the role's trust policy requires an external party identifier
- It has nothing to do with MFA serials; using `mfa_serial` as `ExternalId` causes `AccessDenied` for any role whose trust policy does not include an `ExternalId` condition (which is the common case)
- Removed the `ExternalId` parameter from `MfaAssumeRoleProvider.do_auth`

## Test plan

- [ ] MFA-based role assumption succeeds for a role with no `ExternalId` in its trust policy
- [ ] Confirm `aws sts get-caller-identity` returns expected role ARN after auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)