### PR TITLE
fix: use 'default' as credential name for default profile fallback

### DIFF
--- a/vault/aws/cfg.py
+++ b/vault/aws/cfg.py
@@ -99,7 +99,7 @@ class AwsProfile(object):
         elif nested_profile is not None:
             self.nested = AwsProfile(nested_profile, reader, AwsCredentials(nested_profile), token)
         elif reader.has_section('default') and name != 'default':
-            self.nested = AwsProfile('default', reader, AwsCredentials(nested_profile), token, section_key='')
+            self.nested = AwsProfile('default', reader, AwsCredentials('default'), token, section_key='')
 
     def default_credentials(self):
         if self.creds is not None and self.creds.exists():


### PR DESCRIPTION
## Summary

- In `AwsProfile.__init__`, the `elif` branch that falls back to the `[default]` profile passed `nested_profile` (which is `None` at that point) to `AwsCredentials`
- This created an `AwsCredentials` instance with section name `'None'`, which never matches any real profile section and silently fails credential lookup
- Fixed by passing the string `'default'` to match the actual profile being resolved

## Test plan

- [ ] A profile with no `include_profile`/`source_profile` correctly inherits credentials from `[default]` in `~/.aws/credentials`
- [ ] `pyvault exec --profile=<such-profile> -- aws sts get-caller-identity` succeeds without credential lookup errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)