### PR TITLE
feat: validate MFA token is exactly 6 digits

### DIFF
--- a/vault/aws/auth.py
+++ b/vault/aws/auth.py
@@ -91,8 +91,8 @@ class MfaAssumeRoleProvider(AssumeRoleProvider):
         else:
             value = input()
         value = value.strip()
-        if len(value) != 6:
-            raise ValueError("MFA token should be 6 digits width")
+        if len(value) != 6 or not value.isdigit():
+            raise ValueError("MFA token must be exactly 6 digits")
         return self.sts_client.assume_role(
             RoleSessionName='AssumeRoleSession',
             RoleArn=self.profile['role_arn'],


### PR DESCRIPTION
## Summary

- Previous check only tested `len(value) != 6`; non-digit input like `"ab cdef"` passed locally and failed at the AWS STS API with a cryptic error
- Added `value.isdigit()` so invalid input is caught immediately with a clear message

## Test plan

- [ ] Enter `"abcdef"` → rejected with "MFA token must be exactly 6 digits"
- [ ] Enter `"12 456"` → rejected
- [ ] Enter `"123456"` → accepted, auth proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)