### PR TITLE
feat: enforce 0600 permissions on ~/.aws/tokens

### DIFF
--- a/vault/aws/cfg.py
+++ b/vault/aws/cfg.py
@@ -44,6 +44,7 @@ class AwsTokens(iniIO):
         self.path = expanduser(path)
         with open(self.path, "a+") as _:
             pass
+        os.chmod(self.path, 0o600)
         iniIO.__init__(self, self.path, self.name)
         if self.parser.has_section(name):
             self.token = self.parser[name]


### PR DESCRIPTION
## Summary

- `~/.aws/tokens` was created via `open("a+")` which inherits the process umask — on systems with permissive umask (e.g. 022) this leaves the file world-readable
- AWS credentials in the token cache would be visible to other users on shared systems
- Added `os.chmod(self.path, 0o600)` immediately after file creation, matching the permissions AWS CLI uses for `~/.aws/credentials`

## Test plan

- [ ] Delete `~/.aws/tokens`, run `pyvault exec`, confirm file created with `rw-------` (0600) permissions
- [ ] On existing tokens file with wrong permissions, run any pyvault command and confirm permissions corrected

🤖 Generated with [Claude Code](https://claude.com/claude-code)