### PR TITLE
feat: add timeout to SSO device authorization poll loop

### DIFF
--- a/vault/aws/auth.py
+++ b/vault/aws/auth.py
@@ -160,8 +160,9 @@ class SSORoleProvider(authProvider):
         retry_interval = 5
         if 'interval' in device_creds:
             retry_interval = device_creds['interval']
+        deadline = time.time() + device_creds.get('expiresIn', 600)
 
-        while True:
+        while time.time() < deadline:
             try:
                 token = self.sso_oidc_client.create_token(
                     clientId=client_creds['clientId'],
@@ -177,6 +178,7 @@ class SSORoleProvider(authProvider):
                 else:
                     raise e
             time.sleep(retry_interval)
+        raise TimeoutError("SSO login timed out — device code expired without approval")
 
     def get_token(self):
         token = self.get_oidc_token()


### PR DESCRIPTION
## Summary

- The `get_oidc_token` poll loop ran `while True` with no exit condition other than successful auth
- If the user ignored or missed the browser prompt, the process hung forever requiring a manual kill
- Added a `deadline` from `device_creds['expiresIn']` (typically 600s, matches device code validity) and converted loop to `while time.time() < deadline`
- Raises `TimeoutError` with a clear message when the deadline passes

## Test plan

- [ ] Start SSO auth, do not approve in browser — process exits with timeout error after device code expiry (~10 min)
- [ ] Normal SSO auth (approve in browser) still completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)