### PR TITLE
feat: raise clear error when profile not found in config

### DIFF
--- a/vault/aws/cfg.py
+++ b/vault/aws/cfg.py
@@ -143,6 +143,9 @@ class AwsConfigReader(ProfilesListing):
         pass
 
     def __getitem__(self, profile):
+        section = f"profile {profile}"
+        if not self.config_reader.has_section(section) and not self.config_reader.has_section(profile):
+            raise click.UsageError(f"Profile '{profile}' not found in {self.path}")
         return AwsProfile(profile, self.config_reader, AwsCredentials(profile), AwsTokens(profile))
 
     def list_profiles(self, fn):


### PR DESCRIPTION
## Summary

- Missing AWS profiles caused a cryptic `KeyError` from deep inside `configparser` with no indication of which profile was missing or where to fix it
- Added an explicit existence check in `AwsConfigReader.__getitem__` that raises `click.UsageError` with the profile name and config file path before attempting to construct `AwsProfile`

## Test plan

- [ ] `pyvault exec --profile=nonexistent -- aws s3 ls` → `Error: Profile 'nonexistent' not found in ~/.aws/config`
- [ ] Valid profile still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)