### PR TITLE
feat: configurable RoleSessionName via pyvault_session_name

### DIFF
--- a/vault/aws/auth.py
+++ b/vault/aws/auth.py
@@ -61,9 +61,14 @@ class AssumeRoleProvider(authProvider):
     def client_init(self):
         return self.session.client('sts')
 
+    def _session_name(self):
+        if 'pyvault_session_name' in self.profile:
+            return self.profile['pyvault_session_name']
+        return 'AssumeRoleSession'
+
     def do_auth(self):
         return self.sts_client.assume_role(
-            RoleSessionName='AssumeRoleSession',
+            RoleSessionName=self._session_name(),
             RoleArn=self.profile['role_arn'])
 
     def auth(self):
@@ -94,7 +99,7 @@ class MfaAssumeRoleProvider(AssumeRoleProvider):
         if len(value) != 6:
             raise ValueError("MFA token should be 6 digits width")
         return self.sts_client.assume_role(
-            RoleSessionName='AssumeRoleSession',
+            RoleSessionName=self._session_name(),
             RoleArn=self.profile['role_arn'],
             SerialNumber=self.profile['mfa_serial'],
             TokenCode=value


### PR DESCRIPTION
## Summary

- `RoleSessionName` was hardcoded as `'AssumeRoleSession'` for both `AssumeRoleProvider` and `MfaAssumeRoleProvider`
- This makes CloudTrail audit logs unattributable — all assume-role events look identical regardless of who ran the command
- Added `_session_name()` helper on `AssumeRoleProvider` that reads `pyvault_session_name` from the profile config, falling back to `'AssumeRoleSession'`
- Both `do_auth` implementations use `self._session_name()`

## Usage

In `~/.aws/config`:
```ini
[profile my-production-role]
role_arn = arn:aws:iam::123456789012:role/MyRole
pyvault_session_name = john.doe
```

CloudTrail will now show `john.doe` as the session name for all assumed-role API calls.

## Test plan

- [ ] Set `pyvault_session_name = test-session` in a profile, run `pyvault exec`, confirm session name appears in CloudTrail or via `aws sts get-caller-identity` ARN
- [ ] Profile without `pyvault_session_name` still uses `AssumeRoleSession`

🤖 Generated with [Claude Code](https://claude.com/claude-code)