### PR TITLE
feat: add --force-refresh flag to bypass token cache

### DIFF
--- a/vault/aws/auth.py
+++ b/vault/aws/auth.py
@@ -208,12 +208,15 @@ class SSORoleProvider(authProvider):
 
 
 class Auth(auth.Auth):
-    def __init__(self, profile, mfa_stdin=False, region=None):
+    def __init__(self, profile, mfa_stdin=False, region=None, force_refresh=False):
         self.profile = profile
         self.region = self.profile['region'] if region is None else region
         self.mfa_stdin = mfa_stdin
+        self.force_refresh = force_refresh
 
     def auth(self) -> AuthResponse:
+        if self.force_refresh:
+            return self.do_auth()
         for y in yield_first([self.profile.current, self.do_auth]):
             return y
 

--- a/vault/cli.py
+++ b/vault/cli.py
@@ -25,9 +25,10 @@ def pass_exec_config(fn):
         @click.option("--region", help="AWS region to use")
         @click.option("--config", help="AWS config file", default="~/.aws/config")
         @click.option("--mfa-stdin", help="Read MFA code from stdin", default=False, is_flag=True)
-        def _fn(ctx, profile, config, mfa_stdin, region, *args, **kwargs):
+        @click.option("--force-refresh", help="Force token refresh, bypass cache", default=False, is_flag=True)
+        def _fn(ctx, profile, config, mfa_stdin, region, force_refresh, *args, **kwargs):
             with AwsConfigReader(config_path=config) as config_parser:
-                credentials = auth.Auth(config_parser[profile], mfa_stdin=mfa_stdin, region=region).auth()
+                credentials = auth.Auth(config_parser[profile], mfa_stdin=mfa_stdin, region=region, force_refresh=force_refresh).auth()
                 env = AwsEnv(config_parser[profile], credentials, region=region)
                 obj = ExecConfig(profile, credentials, env, mfa_stdin, region)
             return ctx.invoke(fn, obj, *args, **kwargs)


### PR DESCRIPTION
## Summary

- Added `--force-refresh` flag to `pyvault exec` (via `pass_exec_config`)
- When set, `Auth.auth()` skips `profile.current()` and calls `do_auth()` directly, fetching a fresh token from AWS
- Useful when a cached token is still valid but role policies have changed and a new session is needed

## Usage

```sh
pyvault exec --profile=my-role --force-refresh -- aws s3 ls
```

## Test plan

- [ ] Run `pyvault exec --profile=...` twice; second call uses cache (no MFA prompt)
- [ ] Run with `--force-refresh`; second call re-prompts for MFA / re-does SSO flow
- [ ] Confirm new token written to `~/.aws/tokens` after force refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)