### PR TITLE
feat: add pyvault clear command to invalidate cached tokens

### DIFF
--- a/vault/aws/cfg.py
+++ b/vault/aws/cfg.py
@@ -62,6 +62,18 @@ class AwsTokens(iniIO):
             self.token['session_token'],
             self.token['expiration'])
 
+    def clear(self):
+        if self.parser.has_section(self.name):
+            self.parser.remove_section(self.name)
+            self.flush()
+
+    @classmethod
+    def clear_all(cls, path="~/.aws/tokens"):
+        path = expanduser(path)
+        with open(path, "w") as f:
+            f.write("")
+        os.chmod(path, 0o600)
+
 
 class AwsCredentials(iniIO):
 

--- a/vault/cli.py
+++ b/vault/cli.py
@@ -4,7 +4,7 @@ import click
 from pyfzf import FzfPrompt
 
 from vault.aws import auth
-from vault.aws.cfg import AwsConfigReader, AWSShellInit
+from vault.aws.cfg import AwsConfigReader, AWSShellInit, AwsTokens
 from vault.aws.env import AwsEnv
 from vault.config import Config
 from vault.executor import ExecConfig, Executor
@@ -109,6 +109,20 @@ def get_profile(pyvault_config, raw):
 @click.argument('arguments', nargs=-1, type=click.Path())
 def tool(pyvault_config, tool, arguments):
     AWSShellInit(pyvault_config).shell_exec(tool, list(arguments))
+
+
+@cli.command("clear")
+@click.option("--profile", help="AWS profile to clear cached tokens for")
+@click.option("--all", "all_profiles", is_flag=True, default=False, help="Clear cached tokens for all profiles")
+def clear_tokens(profile, all_profiles):
+    if all_profiles:
+        AwsTokens.clear_all()
+        click.echo("Cleared all cached tokens")
+    elif profile:
+        AwsTokens(profile).clear()
+        click.echo("Cleared cached tokens for profile: " + click.style(profile, fg="green", bold=True))
+    else:
+        raise click.UsageError("Specify --profile=<name> or --all")
 
 
 @cli.command()


### PR DESCRIPTION
## Summary

- No previous way to invalidate cached tokens without manually editing `~/.aws/tokens`
- Added `pyvault clear` command with two modes:
  - `--profile=<name>` — removes the named profile's section from the token cache
  - `--all` — truncates the entire cache file
- Added `AwsTokens.clear()` and `AwsTokens.clear_all()` to `cfg.py`

## Usage

```sh
# Clear one profile
pyvault clear --profile=my-production-role

# Clear everything (e.g. after a security incident)
pyvault clear --all
```

## Test plan

- [ ] `pyvault clear --profile=foo` removes `[foo]` section from `~/.aws/tokens`
- [ ] `pyvault clear --all` empties `~/.aws/tokens`
- [ ] `pyvault clear` (no args) → `UsageError: Specify --profile=<name> or --all`
- [ ] After clear, next `pyvault exec` re-authenticates

🤖 Generated with [Claude Code](https://claude.com/claude-code)