### PR TITLE
feat: add pyvault status command

### DIFF
--- a/vault/cli.py
+++ b/vault/cli.py
@@ -140,6 +140,31 @@ def clear_tokens(profile, all_profiles):
         raise click.UsageError("Specify --profile=<name> or --all")
 
 
+@cli.command("status")
+@click.option("--pyvault-config", help="pyvault config file", default="~/.aws/pyvault")
+def status(pyvault_config):
+    selected = AWSShellInit(pyvault_config).shell_get()
+    profile_name = selected or "default"
+    click.echo("Profile: " + click.style(profile_name, fg="white", bold=True))
+
+    tokens = AwsTokens(profile_name)
+    if tokens.token is None:
+        click.echo("Token:   " + click.style("no cached token", fg="red"))
+        return
+
+    expiration = float(tokens.token['expiration'])
+    remaining = expiration - time.time()
+    if remaining <= 0:
+        click.echo("Token:   " + click.style("expired", fg="red"))
+    elif remaining < 900:
+        mins = int(remaining // 60)
+        click.echo("Token:   " + click.style(f"expires in {mins}m", fg="yellow"))
+    else:
+        hours = int(remaining // 3600)
+        mins = int((remaining % 3600) // 60)
+        click.echo("Token:   " + click.style(f"expires in {hours}h {mins}m", fg="green"))
+
+
 @cli.command()
 def version():
     click.echo(f"pyvault {ver}")


### PR DESCRIPTION
## Summary

- Added `pyvault status` to show the currently selected profile and cached token health at a glance
- Color-coded output:
  - **green** — valid token, shows time remaining (`expires in 2h 15m`)
  - **yellow** — token expiring within 15 minutes
  - **red** — expired or no cached token

## Example output

```
Profile: my-production-role
Token:   expires in 1h 42m
```

## Test plan

- [ ] `pyvault status` with no selected profile → shows `default`, red token if no cache
- [ ] `pyvault status` with valid token → green, correct remaining time
- [ ] `pyvault status` with token expiring in < 15 min → yellow
- [ ] `pyvault status` with expired token → red `expired`

🤖 Generated with [Claude Code](https://claude.com/claude-code)