### PR TITLE
feat: show token expiry status in pyvault list

### DIFF
--- a/vault/cli.py
+++ b/vault/cli.py
@@ -1,10 +1,11 @@
+import time
 from functools import update_wrapper
 
 import click
 from pyfzf import FzfPrompt
 
 from vault.aws import auth
-from vault.aws.cfg import AwsConfigReader, AWSShellInit
+from vault.aws.cfg import AwsConfigReader, AWSShellInit, AwsTokens
 from vault.aws.env import AwsEnv
 from vault.config import Config
 from vault.executor import ExecConfig, Executor
@@ -37,13 +38,26 @@ def pass_exec_config(fn):
     return _decorator()
 
 
+def _token_badge(profile_name):
+    tokens = AwsTokens(profile_name)
+    if tokens.token is None:
+        return click.style("  [no token]", fg="red")
+    remaining = float(tokens.token['expiration']) - time.time()
+    if remaining <= 0:
+        return click.style("  [expired]", fg="red")
+    if remaining < 900:
+        return click.style(f"  [expires in {int(remaining // 60)}m]", fg="yellow")
+    hours, mins = int(remaining // 3600), int((remaining % 3600) // 60)
+    return click.style(f"  [expires in {hours}h {mins}m]", fg="green")
+
+
 @cli.command("list")
 @click.option("--config", help="AWS config file", default="~/.aws/config")
 def profiles_list(config):
     def _dump_prov_profiles(prov, profiles):
         click.echo("Provider: " + click.style(prov, fg="white", bold=True))
         for _profile in profiles:
-            click.secho(f" {_profile}", fg="green")
+            click.echo(click.style(f" {_profile}", fg="green") + _token_badge(_profile))
 
     with AwsConfigReader(config_path=config) as config_parser:
         config_parser.list_profiles(_dump_prov_profiles)


### PR DESCRIPTION
## Summary

- `pyvault list` previously showed only profile names with no auth state
- Added color-coded token badges next to each profile name:
  - **green** `[expires in 2h 15m]` — valid cached token
  - **yellow** `[expires in 8m]` — expiring within 15 minutes
  - **red** `[expired]` — cached token past expiry
  - **red** `[no token]` — no entry in `~/.aws/tokens`

## Example output

```
Provider: AWS
 my-production-role  [expires in 1h 42m]
 my-staging-role     [expires in 4m]
 my-dev-role         [no token]
```

## Test plan

- [ ] Profile with valid token shows green badge with correct time
- [ ] Profile with expiring token (< 15 min) shows yellow
- [ ] Profile with expired token shows red `[expired]`
- [ ] Profile never authenticated shows red `[no token]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)