### PR TITLE
feat: add pyvault whoami command

### DIFF
--- a/vault/cli.py
+++ b/vault/cli.py
@@ -1,6 +1,7 @@
 import time
 from functools import update_wrapper
 
+import boto3
 import click
 from pyfzf import FzfPrompt
 
@@ -163,6 +164,22 @@ def status(pyvault_config):
         hours = int(remaining // 3600)
         mins = int((remaining % 3600) // 60)
         click.echo("Token:   " + click.style(f"expires in {hours}h {mins}m", fg="green"))
+
+
+@cli.command("whoami")
+@click.argument('arguments', nargs=-1, type=click.Path())
+@pass_exec_config
+def whoami(exec_cfg: ExecConfig, arguments):
+    creds = exec_cfg.credentials
+    session = boto3.Session(
+        aws_access_key_id=creds.aws_access_key_id,
+        aws_secret_access_key=creds.aws_secret_access_key,
+        aws_session_token=creds.aws_session_token)
+    identity = session.client('sts').get_caller_identity()
+    click.echo("Profile:    " + click.style(exec_cfg.profile, fg="white", bold=True))
+    click.echo("Account:    " + click.style(identity['Account'], fg="green"))
+    click.echo("UserId:     " + click.style(identity['UserId'], fg="green"))
+    click.echo("Arn:        " + click.style(identity['Arn'], fg="green"))
 
 
 @cli.command()


### PR DESCRIPTION
## Summary

- Added `pyvault whoami` — calls `sts:GetCallerIdentity` with the resolved profile credentials and prints `Account`, `UserId`, and `Arn`
- Uses `pass_exec_config` so it goes through the same auth flow (cache, MFA, SSO) as `pyvault exec`
- Instant check for "which identity am I currently operating as?" without needing to run `aws sts get-caller-identity` separately

## Example output

```
Profile:    my-production-role
Account:    123456789012
UserId:     AROAEXAMPLE:john.doe
Arn:        arn:aws:sts::123456789012:assumed-role/MyRole/john.doe
```

## Test plan

- [ ] `pyvault whoami --profile=<name>` prints correct account/ARN for the role
- [ ] Works with MFA, assume-role, and SSO profiles
- [ ] Requires valid credentials (triggers auth flow if not cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)